### PR TITLE
site: narrative rewrite — plugin to bare metal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,118 +1,151 @@
 # Evolving Agents Labs
 
-## About Our Research
+**Agents defined in markdown. Evolved through memory. Running from Claude Code to bare metal.**
 
-We explore early-stage concepts in adaptive AI through experimental frameworks and research prototypes. Our work investigates how intelligent agents might adapt, learn, and evolve their behavior based on context, user interaction, and accumulated experience.
-
-**All projects remain permanently in alpha status as ongoing research experiments.**
+One thesis explored at five levels of depth: agent behavior belongs in declarative documents, the LLM is the interpreter, memory is how agents improve, and grammar/structure is how you keep them safe.
 
 ---
 
-## 📢 Project Evolution Announcement
+## The Stack
 
-### Original Evolving Agents Toolkit (EAT) - Sunset Notice
+Each layer removes a safety net. Each one proves the same patterns work at increasing depth.
 
-The original [Evolving Agents Toolkit (EAT) Python project](https://github.com/matiasmolinas/evolving-agents) has been **officially discontinued** as of July 2025. While EAT demonstrated powerful concepts in multi-agent orchestration with MongoDB backend, we recognized that the complex Python architecture was over-engineered for achieving adaptive agent behavior.
-
-**Key insights from EAT that led to our new direction:**
-- Complex multi-component architectures created unnecessary overhead
-- The core concept of autonomous agent evolution was sound
-- Simpler approaches could achieve the same adaptive behaviors
-- LLM capabilities alone could handle orchestration and evolution
-
-### Evolution to LLMunix
-
-The concepts pioneered in EAT have been **dramatically simplified and reimplemented** in our new flagship project: **LLMunix** - a Pure Markdown Operating System that achieves the same adaptive agent goals through elegant simplicity.
-
-**From EAT's complexity to LLMunix's simplicity:**
-- **EAT**: Multi-component Python architecture with MongoDB backend
-- **LLMunix**: Pure markdown definitions interpreted by LLM runtime engines
-- **Result**: Same adaptive capabilities, 10x simpler implementation
-
-### Current Focus & Next Steps
-
-We are actively **maintaining and evolving LLMunix** as our core research platform. However, with the recent implementation of **sub-agents in markdown as an official Claude Code feature**, we now understand that our original markdown-based agent concept was an excellent proof-of-concept that has been validated by the industry.
-
-**Our new research direction:**
-- **LLMunix continues** as a maintained research platform for markdown-based agent systems
-- **Next frontier**: Implementing agents and their tools **directly at the LLM level**
-- **Goal**: Move beyond markdown specifications to native LLM-based agent architectures
-- **Focus**: Developing truly autonomous agents that exist within the LLM's reasoning space
-
-This represents the natural evolution from external frameworks → markdown specifications → **pure LLM-native agent implementation**.
+```
+                         ┌───────────────┐
+                         │    llm_os     │  LLM is the CPU. 14-opcode ISA.
+                         │    (Rust)     │  GBNF grammar = type system.
+                     ┌───┴───────────────┴───┐
+                     │     skillos_robot      │  VLM-driven robot. $30 hardware.
+                     │     (TypeScript)       │  Dream consolidation.
+                 ┌───┴───────────────────────┴───┐
+                 │        skillos_mini            │  On-device. 2B model. No internet.
+                 │        (Svelte/Capacitor)      │  Deterministic safety checks.
+             ┌───┴───────────────────────────────┴───┐
+             │              skillos                    │  Full markdown OS. Any LLM.
+             │              (Pure Markdown)            │  Memory + evolution + planning.
+         ┌───┴───────────────────────────────────────┴───┐
+         │     skillos_plugin + skillos_systemcontrol      │  Try it now. /skillos + /sysctl.
+         │     (Claude Code plugins)                       │  Install in 10 seconds.
+         └─────────────────────────────────────────────────┘
+```
 
 ---
 
-## 🧪 Current Experiments
+## Projects
 
-### [LLMunix](https://github.com/EvolvingAgentsLabs/llmunix) `ALPHA`
-**Pure Markdown Operating System**
-- Revolutionary Pure Markdown Operating System designed to be run by multiple AI runtime engines
-- Compatible with Claude Code and Claude Code sub agents, Gemini CLI, and Qwen Code
-- Features multi-tier memory, inter-agent messaging, and dynamic evolution capabilities
-- Runtime engines interpret the manifest file to turn markdown specifications into a functional operating system
+### Try it now (Claude Code plugins)
 
-[📖 Learn More](https://evolvingagentslabs.github.io/experiments/llmunix.html) • [🚀 View Project](https://github.com/EvolvingAgentsLabs/llmunix)
+| Repo | Command | What it does |
+|---|---|---|
+| **[skillos_plugin](https://github.com/EvolvingAgentsLabs/skillos_plugin)** | `/skillos` | Goal decomposition, agent creation, execution, memory consolidation. The easiest way to explore SkillOS concepts. |
+| **[skillos_systemcontrol_plugin](https://github.com/EvolvingAgentsLabs/skillos_systemcontrol_plugin)** | `/sysctl` | Security audits, agent scoring, controlled evolution, lifecycle management. Governs what `/skillos` builds. |
 
-### [Agent Forge](https://github.com/EvolvingAgentsLabs/agent-forge) `ALPHA`
-**JIT Agent Architecture Framework**
-- Comprehensive framework for just-in-time agent architectures featuring three specialized proof-of-concept implementations
-- Explores unified Qwen model architectures, reinforcement learning capabilities, and persistent memory systems
-- Features dynamic tool generation, benchmarkable performance improvements, and modular POC comparison
-- Includes comprehensive documentation and guides for each POC implementation
-
-[📖 Learn More](https://evolvingagentslabs.github.io/experiments/agent-forge.html) • [🚀 View Project](https://github.com/EvolvingAgentsLabs/agent-forge)
-
-#### Agent Forge POC Implementations
-
-- **[├── jit-agent-poc](https://github.com/EvolvingAgentsLabs/agent-forge/tree/main/jit-agent-poc)** `ALPHA` - Unified Qwen Architecture POC: Single fine-tuned Qwen2.5-Coder-1.5B model as both Orchestrator and Translator, eliminating multi-model complexity through specialized LoRA training
-- **[├── jit-agent-learn](https://github.com/EvolvingAgentsLabs/agent-forge/tree/main/jit-agent-learn)** `ALPHA` - Learning & Adaptation POC: Reinforcement learning capabilities allowing agents to improve performance through experience and feedback loops using Qwen models
-- **[└── jit-agent-memory](https://github.com/EvolvingAgentsLabs/agent-forge/tree/main/jit-agent-memory)** `ALPHA` - Persistent Memory POC: Advanced memory capabilities enabling contextual awareness and long-term information retention using Qwen models
+```bash
+/skillos "Build a REST API with auth and tests"
+/sysctl "audit and score all agents in Project_webapp"
+```
 
 ---
 
-## 🔬 Research Areas
+### Full system (markdown-defined agent OS)
 
-| Focus Area | Description |
-|------------|-------------|
-| **Adaptive Behavior Research** | How agents might modify decision-making based on context and interaction patterns |
-| **Pure Markdown Architecture** | Exploring the use of markdown as a full operating system specification, enabling clean separation of behavior, state, and execution logic |
-| **JIT Compilation Systems** | Dynamic compilation of executable code from LLM-provided conceptual ideas for enhanced performance |
-| **Memory System Experiments** | Persistent memory capabilities for contextual awareness and long-term information retention |
-| **Self-Improving Learning** | Reinforcement learning capabilities allowing agents to improve through experience and feedback loops |
-| **Hybrid Agent Architectures** | Combining multiple AI models and fine-tuned components for enhanced agent capabilities |
+**[skillos](https://github.com/EvolvingAgentsLabs/skillos)** &mdash; Pure Markdown Operating System
 
----
+Every component &mdash; agents, tools, memory, orchestration &mdash; defined entirely in `.md` files interpreted by any LLM at runtime. No code compilation. The LLM is the interpreter.
 
-## 🌐 Explore Our Research Lab
-
-**👉 [Visit evolvingagentslabs.github.io](https://evolvingagentslabs.github.io) for the complete research showcase**
-
-### Quick Navigation
-- 🔬 [View All Experiments](https://evolvingagentslabs.github.io#experiments)
-- 📊 [Research Overview](https://evolvingagentslabs.github.io#about)  
-- 📖 [LLMunix Deep Dive](https://evolvingagentslabs.github.io/experiments/llmunix.html)
-- 🛠️ [Try LLMunix](https://github.com/EvolvingAgentsLabs/llmunix#quick-start)
+- HWM two-level hierarchical planning (arXiv:2604.03208)
+- 14 domain-specific dialects (50-99% token compression)
+- Bio-inspired dream consolidation (traces become strategies overnight)
+- Self-optimization loop (detect stale skills, propose improvements)
+- Multi-provider: Claude, Gemini, Gemma 4, any OpenAI-compatible endpoint
+- Validated on complex multi-agent scenarios (Operation Echo-Q, Project Aorta)
 
 ---
 
-## ⚠️ Experimental Nature
+### On-device (mobile democratization)
 
-**Important**: All our projects are research prototypes exploring early-stage concepts. They should be treated as experimental research material rather than production-ready systems. We believe in transparent, open research that advances the field through shared exploration.
+**[skillos_mini](https://github.com/EvolvingAgentsLabs/skillos_mini)** &mdash; On-device trade assistant for Android
 
----
+Same architectural patterns running on a phone with a 2B model. Markdown cartridges (documents with embedded tool-calls) guide the LLM through trade diagnostics. The LLM picks links and decides which optional checks to run &mdash; all safety rules execute as deterministic TypeScript functions.
 
-## 🤝 Contributing
-
-We welcome researchers, developers, and curious minds to explore our work:
-
-- **🔍 Explore**: Browse our experiments and documentation
-- **🐛 Report**: Share findings or issues you discover  
-- **💡 Discuss**: Join conversations about adaptive agent concepts
-- **🧪 Experiment**: Build upon our research prototypes
+- Three production cartridges: electricista (IEC 60364), plomero, pintor
+- Gemma 4 on-device via LiteRT &mdash; no internet required
+- Regulatory compliance by construction (deterministic validators)
+- Navigator state machine: IDLE &rarr; ROUTING &rarr; WALKING &rarr; COMPOSING &rarr; DONE
 
 ---
 
-## 📄 License
+### Real world (embodied cognition)
 
-All projects are released under the Apache 2.0 License.
+**[skillos_robot](https://github.com/EvolvingAgentsLabs/skillos_robot)** &mdash; VLM-driven robot navigation
+
+A 20cm robot that sees through a camera, reasons about the scene, and drives to the target. Give it a goal in plain language. Same patterns &mdash; markdown traces, dream consolidation, strategy extraction &mdash; but in the physical world with $30 of hardware.
+
+- Dual loop: VLM perception (1-2 Hz) + reactive motor control (10-20 Hz)
+- Two modes: overhead camera (arena) or egocentric (first-person, no IMU)
+- Failed traces get retried in MuJoCo simulation during dream consolidation
+- Gemini (cloud teacher) or Ollama (local student, no internet)
+
+---
+
+### Bare metal (the LLM as CPU)
+
+**[llm_os](https://github.com/EvolvingAgentsLabs/llm_os)** &mdash; An OS where the LLM is the CPU
+
+The maximum expression of these ideas. The LLM doesn't use tools &mdash; it *is* the processor. A 14-opcode ISA enforced by GBNF grammar at decode time. Invalid instruction sequences are physically impossible to emit. KV cache is RAM. Grammar is the type system. Cartridges are syscalls. Boots from an SD card on a Raspberry Pi 5.
+
+- In-process inference via Rust FFI to llama.cpp (no HTTP boundary)
+- Deterministic KV paging with anchors (no LLM summarization)
+- WASM-sandboxed cartridges with curated host functions (real Ring 3)
+- Single-token ISA fine-tune pipeline (20 opcodes, exact capability enforcement)
+- Dual deployment: dev mode (macOS/Linux) + release mode (Buildroot Pi 5 image)
+
+---
+
+## The Unifying Patterns
+
+Across all five layers, the same patterns recur:
+
+| Pattern | Plugin | SkillOS | Trade App | Robot | LLM-OS |
+|---|---|---|---|---|---|
+| Declarative behavior | markdown agents | markdown agents | markdown cartridges | markdown traces | GBNF grammar |
+| Memory consolidation | dream command | dream engine | session blackboard | dream retries | KV pager + state |
+| Capability control | human approval | policy masks | tool whitelists | motor limits | logit bias + WASM |
+| Composable units | agent triads | skills (domain/family) | cartridge docs | navigation strategies | cartridges + schemas |
+| LLM as interpreter | Claude | any LLM | Gemma 2B | Gemini VLM | Qwen 3B (the CPU itself) |
+
+---
+
+## Research Direction
+
+**From external frameworks &rarr; markdown specifications &rarr; LLM-native execution.**
+
+The original Evolving Agents Toolkit (Python, MongoDB, 2025) proved the concept. SkillOS proved markdown alone is sufficient. LLM-OS proves you can push it all the way down to the hardware level &mdash; the LLM doesn't call tools, it *is* the processor, constrained by grammar the way a CPU is constrained by its instruction decoder.
+
+---
+
+## Quick Start
+
+The fastest path from zero to working:
+
+```bash
+# 1. Install the Claude Code plugin (10 seconds)
+/plugin install skillos-plugin
+
+# 2. Give it a goal
+/skillos "Research quantum computing and write a summary"
+
+# 3. See what it built
+ls projects/
+
+# 4. Consolidate learnings
+/skillos dream
+```
+
+Then go deeper: clone `skillos` for the full system, `skillos_mini` for mobile, `skillos_robot` for embodiment, `llm_os` for bare metal.
+
+---
+
+Apache 2.0 &middot; permanently alpha &middot; 2026
+
+[evolvingagentslabs.github.io](https://evolvingagentslabs.github.io)

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Evolving Agents Labs</title>
-  <meta name="description" content="On-device adaptive AI. Six open-source experiments. Apache 2.0."/>
+  <meta name="description" content="Agents defined in markdown. Evolved through memory. Running from Claude Code to bare metal."/>
   <meta property="og:title" content="Evolving Agents Labs"/>
-  <meta property="og:description" content="On-device adaptive AI. Six open-source experiments."/>
+  <meta property="og:description" content="Agents defined in markdown. Evolved through memory. Running from Claude Code to bare metal."/>
   <link rel="icon" type="image/png" href="images/avatar.png"/>
   <link rel="stylesheet" href="styles.css"/>
 </head>
@@ -17,6 +17,7 @@
       <a class="logo" href="#">EVOLVING AGENTS LABS</a>
       <nav>
         <a href="#projects">projects</a>
+        <a href="#thesis">thesis</a>
         <a href="https://github.com/EvolvingAgentsLabs" target="_blank" rel="noopener">github</a>
       </nav>
     </div>
@@ -26,24 +27,43 @@
 
     <section class="hero">
       <div class="container">
-        <h1>On-device adaptive AI</h1>
-        <p class="subtitle">Six open-source experiments mapping a cognitive stack onto local LLMs.</p>
+        <h1>Agents defined in markdown.<br/>Evolved through memory.<br/>Running from Claude Code to bare metal.</h1>
+        <p class="subtitle">Six open-source experiments mapping a cognitive stack onto local LLMs &mdash; from a Claude Code plugin you install in 10 seconds to a Rust OS where the LLM is the CPU.</p>
         <p class="meta">Apache 2.0 &middot; permanently alpha &middot; 2026</p>
+      </div>
+    </section>
+
+    <section id="thesis" class="thesis">
+      <div class="container">
+        <div class="thesis-content">
+          <p>One thesis, five layers of depth. Each project removes a safety net:</p>
+          <ol class="thesis-steps">
+            <li><strong>Plugin</strong> &mdash; Claude does everything. You just give it a goal.</li>
+            <li><strong>Full system</strong> &mdash; Any LLM interprets markdown agents. Memory consolidation. Self-optimization.</li>
+            <li><strong>On-device</strong> &mdash; A 2B model on a phone. No internet. Deterministic safety checks.</li>
+            <li><strong>Real world</strong> &mdash; $30 robot. VLM sees, reasons, drives. Failed runs retry in simulation overnight.</li>
+            <li><strong>Bare metal</strong> &mdash; The LLM is the CPU. 14-opcode ISA. GBNF grammar = MMU. Runs on a Pi 5.</li>
+          </ol>
+        </div>
       </div>
     </section>
 
     <section id="projects" class="projects">
       <div class="container">
 
+        <div class="layer-label">Start here &mdash; try in 30 seconds</div>
+
         <article class="project">
           <div class="project-header">
-            <h2><a href="https://github.com/EvolvingAgentsLabs/skillos">skillos</a></h2>
-            <span class="tag">markdown OS</span>
+            <h2><a href="https://github.com/EvolvingAgentsLabs/skillos_plugin">skillos_plugin</a></h2>
+            <span class="tag">Claude Code plugin</span>
           </div>
-          <p>Define agents, tools, and memory as <code>.md</code> files. Run them on Claude Code, Gemini CLI, or a 2B local model. Dream consolidation turns traces into strategies overnight.</p>
-          <pre><code><span class="prompt">$</span> /skillos "Plan a weekly menu for 4 people"
-<span class="ok">[OK]</span> agent created   MenuPlannerAgent
-<span class="ok">[OK]</span> output          projects/Menu/output/menu.md
+          <p>Install in Claude Code, type <code>/skillos</code> with a goal. It decomposes the task, creates specialized agents as markdown, executes them, and consolidates learnings into memory. The fastest way to explore SkillOS concepts.</p>
+          <pre><code><span class="prompt">$</span> /plugin install skillos-plugin
+
+<span class="prompt">$</span> /skillos "Build a REST API with auth and tests"
+<span class="ok">[OK]</span> agents          3 created &middot; triad decomposition
+<span class="ok">[OK]</span> output          projects/API/output/
 
 <span class="prompt">$</span> /skillos dream
 <span class="ok">[OK]</span> strategies      3 new &middot; 2 updated</code></pre>
@@ -51,23 +71,10 @@
 
         <article class="project">
           <div class="project-header">
-            <h2><a href="https://github.com/EvolvingAgentsLabs/skillos_plugin">skillos_plugin</a></h2>
-            <span class="tag">Claude Code plugin</span>
-          </div>
-          <p>Install skillos as a Claude Code plugin. Adds the <code>/skillos</code> command &mdash; goal decomposition, agent creation, execution, and memory in one prompt.</p>
-          <pre><code><span class="prompt">$</span> /plugin install ./skillos_plugin/skillos-plugin
-<span class="ok">[OK]</span> installed       skillos-plugin v1.1.0
-
-<span class="prompt">$</span> /skillos "Build a REST API with auth and tests"
-<span class="ok">[OK]</span> agents          3 created &middot; triad decomposition</code></pre>
-        </article>
-
-        <article class="project">
-          <div class="project-header">
             <h2><a href="https://github.com/EvolvingAgentsLabs/skillos_systemcontrol_plugin">skillos_systemcontrol_plugin</a></h2>
             <span class="tag">governance</span>
           </div>
-          <p>Control plane for skillos projects. Security audits, agent scoring, controlled evolution, and lifecycle management. Never modifies files directly &mdash; produces reports for human approval.</p>
+          <p>Companion to <code>/skillos</code>. The <code>/sysctl</code> command audits, scores, evolves, and prunes what <code>/skillos</code> built. Security scans, 7-type failure taxonomy, anti-overfitting gate, lifecycle management. Never modifies files directly &mdash; produces proposals for human approval.</p>
           <pre><code><span class="prompt">$</span> /sysctl "audit and score all agents in Project_webapp"
 <span class="ok">[OK]</span> security        9 checks passed &middot; 0 critical
 <span class="ok">[OK]</span> scores          AgentA: S(0.92) &middot; AgentB: A(0.78)
@@ -76,40 +83,70 @@
 <span class="ok">[OK]</span> proposals       2 minimal-surface edits &middot; awaiting approval</code></pre>
         </article>
 
+        <div class="layer-label">Full system &mdash; markdown-defined agent OS</div>
+
+        <article class="project">
+          <div class="project-header">
+            <h2><a href="https://github.com/EvolvingAgentsLabs/skillos">skillos</a></h2>
+            <span class="tag">markdown OS</span>
+          </div>
+          <p>The full SkillOS. Every component &mdash; agents, tools, memory, orchestration &mdash; defined in <code>.md</code> files interpreted by any LLM at runtime. HWM hierarchical planning, 14 token-compression dialects, dream consolidation, self-optimization loop. Runs on Claude, Gemini, Gemma 4, or any OpenAI-compatible endpoint.</p>
+          <pre><code><span class="prompt">$</span> skillos execute: "Run the Operation Echo-Q scenario"
+<span class="ok">[OK]</span> agents          4 created &middot; quantum theorist &rarr; architect
+<span class="ok">[OK]</span> wiki            5 concept pages &middot; LaTeX
+<span class="ok">[OK]</span> code            quantum_cepstrum.py &middot; echo error 0.003s
+
+<span class="prompt">$</span> skillos execute: "Run the Project Aorta scenario"
+<span class="ok">[OK]</span> output          36KB clinical vision + 37KB math framework</code></pre>
+        </article>
+
+        <div class="layer-label">On-device &mdash; same concepts on a phone</div>
+
         <article class="project">
           <div class="project-header">
             <h2><a href="https://github.com/EvolvingAgentsLabs/skillos_mini">skillos_mini</a></h2>
             <span class="tag">Android &middot; on-device</span>
           </div>
-          <p>Capacitor + Svelte 5 trade-app for tradespeople. Gemma 4 vision runs on-device via LiteRT. Capture a photo, get a diagnosis, generate a branded PDF, share via WhatsApp. No backend.</p>
-          <pre><code><span class="prompt">$</span> npm run dev
-<span class="ok">[OK]</span> cartridges      trade-electricista &middot; trade-plomero &middot; trade-pintor
-<span class="ok">[OK]</span> vision          gemma-4-e2b &middot; on-device &middot; ~200ms</code></pre>
+          <p>Markdown cartridges guide a 2B local LLM through trade diagnostics. Electrician (IEC 60364), plumber, painter. The LLM picks links and decides which optional checks to run &mdash; all safety rules execute as deterministic TypeScript functions. No internet required. Gemma 4 on-device via LiteRT.</p>
+          <pre><code><span class="prompt">chat:</span> "panel has exposed wiring and no RCD"
+<span class="ok">[OK]</span> route           electricista &rarr; diagnosis_cableado.md
+<span class="ok">[OK]</span> mandatory       electrical.checkWireGauge &rarr; FALLA
+<span class="ok">[OK]</span> adaptive        safety.checkRCD &rarr; PELIGRO
+<span class="ok">[OK]</span> diagnosis       Recableado 4mm&sup2; + diferencial 30mA</code></pre>
         </article>
+
+        <div class="layer-label">Real world &mdash; embodied cognition for $30</div>
 
         <article class="project">
           <div class="project-header">
             <h2><a href="https://github.com/EvolvingAgentsLabs/skillos_robot">skillos_robot</a></h2>
             <span class="tag">robot &middot; VLM</span>
           </div>
-          <p>A 20cm cube robot driven by a vision language model. Give it a goal &mdash; it sees through the camera, reasons about the scene, and drives to the target. Failed runs get retried in MuJoCo overnight.</p>
+          <p>A 20cm robot driven by a vision language model. Give it a goal &mdash; it sees through the camera, reasons about the scene, and drives to the target. Dual loop: VLM perception at 1&ndash;2 Hz, reactive motor control at 10&ndash;20 Hz. Failed traces get retried in MuJoCo simulation during dream consolidation.</p>
           <pre><code><span class="prompt">$</span> robot navigate "go to the red cube"
 <span class="ok">[OK]</span> vlm             gemini-3.1-flash-lite &middot; 200ms/frame
 <span class="ok">[OK]</span> navigation      target reached &middot; 12 steps
 
 <span class="prompt">$</span> robot dream
-<span class="ok">[OK]</span> retried         3 failed traces in MuJoCo</code></pre>
+<span class="ok">[OK]</span> retried         3 failed traces in MuJoCo
+<span class="ok">[OK]</span> strategies      "approach from left" &rarr; confidence 0.85</code></pre>
         </article>
+
+        <div class="layer-label">Bare metal &mdash; the LLM is the CPU</div>
 
         <article class="project">
           <div class="project-header">
             <h2><a href="https://github.com/EvolvingAgentsLabs/llm_os">llm_os</a></h2>
-            <span class="tag">LLM as CPU</span>
+            <span class="tag">LLM as CPU &middot; Rust</span>
           </div>
-          <p>An OS where the LLM is the CPU. 13-opcode ISA enforced by GBNF grammar &mdash; invalid sequences are physically impossible to emit. KV cache as RAM. Runs on a Raspberry Pi 5.</p>
+          <p>An OS where the LLM is the CPU. 14-opcode ISA enforced by GBNF grammar at decode time &mdash; invalid sequences are physically impossible to emit. In-process inference via FFI to llama.cpp. KV cache as RAM with deterministic paging. WASM-sandboxed cartridges. Boots from SD card on a Raspberry Pi 5 at 8 Hz.</p>
           <pre><code><span class="prompt">$</span> bash scripts/dev.sh --model qwen2.5-3b-q4.gguf
-<span class="ok">[OK]</span> grammar         isa.gbnf &middot; 13 opcodes
+<span class="ok">[OK]</span> sampler         in-process FFI &middot; grammar stack loaded
 <span class="ok">[OK]</span> cartridges      6 mounted &middot; system &middot; io &middot; domestic
+
+<span class="prompt">$</span> iod dispatch "plan a weekly menu for a family of 4"
+<span class="ok">[OK]</span> opcodes         call &rarr; result &rarr; call &rarr; halt
+<span class="ok">[OK]</span> trace           14 tokens &middot; 3 syscalls &middot; 1.2s total
 
 <span class="prompt">$</span> bash image/build.sh --model qwen2.5-3b-q4.gguf
 <span class="ok">[OK]</span> image           pi5-sdcard.img &middot; 1.8GB</code></pre>

--- a/styles.css
+++ b/styles.css
@@ -121,10 +121,76 @@ nav a:hover { color: var(--accent); text-decoration: none; }
   letter-spacing: 0.5px;
 }
 
+/* ─── Thesis ─── */
+
+.thesis {
+  padding: 48px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.thesis-content p {
+  color: var(--text-dim);
+  margin-bottom: 16px;
+}
+
+.thesis-steps {
+  list-style: none;
+  counter-reset: step;
+  padding: 0;
+}
+
+.thesis-steps li {
+  counter-increment: step;
+  position: relative;
+  padding-left: 32px;
+  margin-bottom: 10px;
+  color: var(--text-dim);
+  font-size: 15px;
+}
+
+.thesis-steps li::before {
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+  background: var(--accent-dim);
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 2px;
+}
+
+.thesis-steps li strong {
+  color: var(--text);
+}
+
 /* ─── Projects ─── */
 
 .projects {
   padding: 48px 0 64px;
+}
+
+.layer-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 32px 0 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+}
+
+.layer-label:first-child {
+  margin-top: 0;
+  border-top: none;
+  padding-top: 0;
 }
 
 .project {


### PR DESCRIPTION
## Summary

- Restructures the site and org README around the spectrum of depth:
  1. **Plugin** (try in 30 seconds) — `/skillos` + `/sysctl` in Claude Code
  2. **Full system** — skillos markdown OS, any LLM, memory + evolution
  3. **On-device** — skillos_mini trade app, 2B model, no internet
  4. **Real world** — skillos_robot, VLM navigation, $30 hardware
  5. **Bare metal** — llm_os, LLM as CPU, 14-opcode ISA, Pi 5

- **index.html**: New thesis section with numbered steps, layer-label separators between project groups, updated project descriptions reflecting latest state (14 opcodes, FFI inference, WASM sandbox)
- **styles.css**: Thesis steps with numbered circles, layer-label uppercase separators
- **README.md**: Complete org profile rewrite with stack pyramid diagram, unifying-patterns table, research direction section, and quick-start guide

## Test plan

- [ ] Deploy to GitHub Pages and verify rendering
- [ ] Check mobile responsiveness (thesis + layer labels)
- [ ] Verify all repo links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)